### PR TITLE
specify MCV discourse URL

### DIFF
--- a/config/plugins/sourcecred/discourse/config.json
+++ b/config/plugins/sourcecred/discourse/config.json
@@ -1,1 +1,1 @@
-{"serverUrl": "https://sourcecred-test.discourse.group"}
+{"serverUrl": "https://hideout.metacartel.xyz"}


### PR DESCRIPTION
Set Hideout URL for Discourse plugin instead of placeholder